### PR TITLE
Set scope "provided" for org.jetbrains:annotations:19.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <version>19.0.0</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
If we set "provided" for "annotations" library, clients of skija still get benefits of annotations:

![image](https://user-images.githubusercontent.com/5963351/86122304-46b61480-bae0-11ea-8ae8-681ff405534b.png)
![image](https://user-images.githubusercontent.com/5963351/86122411-79600d00-bae0-11ea-9f85-d3b1d473d6f7.png)
