### PR TITLE
Prototype of correct reachability management for objects with native …

### DIFF
--- a/native/src/Canvas.cc
+++ b/native/src/Canvas.cc
@@ -96,9 +96,9 @@ extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skija_Canvas__1nDrawPath
 }
 
 extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skija_Canvas__1nDrawImageRect
-  (JNIEnv* env, jclass jclass, jlong canvasPtr, jlong imagePtr, jfloat sl, jfloat st, jfloat sr, jfloat sb, jfloat dl, jfloat dt, jfloat dr, jfloat db, jlong paintPtr, jboolean strict) {
+  (JNIEnv* env, jclass jclass, jlong canvasPtr, jobject imageJvm, jfloat sl, jfloat st, jfloat sr, jfloat sb, jfloat dl, jfloat dt, jfloat dr, jfloat db, jlong paintPtr, jboolean strict) {
     SkCanvas* canvas = reinterpret_cast<SkCanvas*>(static_cast<uintptr_t>(canvasPtr));
-    SkImage* image = reinterpret_cast<SkImage*>(static_cast<uintptr_t>(imagePtr));
+    SkImage* image = getNativePtr<SkImage>(env, imageJvm);
     SkRect src {sl, st, sr, sb};
     SkRect dst {dl, dt, dr, db};
     SkPaint* paint = reinterpret_cast<SkPaint*>(static_cast<uintptr_t>(paintPtr));
@@ -107,9 +107,9 @@ extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skija_Canvas__1nDrawImageRe
 }
 
 extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skija_Canvas__1nDrawImageIRect
-  (JNIEnv* env, jclass jclass, jlong canvasPtr, jlong imagePtr, jint sl, jint st, jint sr, jint sb, jfloat dl, jfloat dt, jfloat dr, jfloat db, jlong paintPtr, jboolean strict) {
+  (JNIEnv* env, jclass jclass, jlong canvasPtr, jobject imageJvm, jint sl, jint st, jint sr, jint sb, jfloat dl, jfloat dt, jfloat dr, jfloat db, jlong paintPtr, jboolean strict) {
     SkCanvas* canvas = reinterpret_cast<SkCanvas*>(static_cast<uintptr_t>(canvasPtr));
-    SkImage* image = reinterpret_cast<SkImage*>(static_cast<uintptr_t>(imagePtr));
+    SkImage* image = getNativePtr<SkImage>(env, imageJvm);
     SkIRect src {sl, st, sr, sb};
     SkRect dst {dl, dt, dr, db};
     SkPaint* paint = reinterpret_cast<SkPaint*>(static_cast<uintptr_t>(paintPtr));

--- a/native/src/interop.hh
+++ b/native/src/interop.hh
@@ -275,3 +275,15 @@ std::vector<SkString> skStringVector(JNIEnv* env, jobjectArray arr);
 jobjectArray javaStringArray(JNIEnv* env, const std::vector<SkString>& strings);
 
 void deleteJBytes(void* addr, void*);
+
+// On top level to allow instance sharing accross template instantiations.
+static jfieldID ptrFieldId = nullptr;
+template <typename T>
+T* getNativePtr(JNIEnv* env, jobject native) {
+    if (!ptrFieldId) {
+        jclass nativeClass = env->FindClass("org/jetbrains/skija/impl/Native");
+        ptrFieldId = env->GetFieldID(nativeClass, "_ptr", "J");
+    }
+    return reinterpret_cast<T*>(
+        static_cast<uintptr_t>(native ? env->GetLongField(native, ptrFieldId) : 0));
+}

--- a/shared/src/main/java/org/jetbrains/skija/Canvas.java
+++ b/shared/src/main/java/org/jetbrains/skija/Canvas.java
@@ -1,5 +1,6 @@
 package org.jetbrains.skija;
 
+import java.lang.ref.Reference;
 import org.jetbrains.annotations.*;
 import org.jetbrains.skija.impl.*;
 
@@ -258,7 +259,8 @@ public class Canvas extends Managed {
 
     public Canvas drawImage(Image image, float left, float top, Paint paint) {
         Stats.onNativeCall();
-        _nDrawImageIRect(_ptr, Native.getPtr(image), 0, 0, image.getWidth(), image.getHeight(), left, top, left + image.getWidth(), top + image.getHeight(), Native.getPtr(paint), true);
+        long imagePtr = Native.getPtr(image);
+        _nDrawImageIRect(_ptr, image, 0, 0, image.getWidth(), image.getHeight(), left, top, left + image.getWidth(), top + image.getHeight(), Native.getPtr(paint), true);
         return this;
     }
 
@@ -268,7 +270,7 @@ public class Canvas extends Managed {
 
     public Canvas drawImageRect(Image image, Rect dst, Paint paint) {
         Stats.onNativeCall();
-        _nDrawImageIRect(_ptr, Native.getPtr(image), 0, 0, image.getWidth(), image.getHeight(), dst._left, dst._top, dst._right, dst._bottom, Native.getPtr(paint), true);
+        _nDrawImageIRect(_ptr, image, 0, 0, image.getWidth(), image.getHeight(), dst._left, dst._top, dst._right, dst._bottom, Native.getPtr(paint), true);
         return this;
     }
 
@@ -278,7 +280,7 @@ public class Canvas extends Managed {
 
     public Canvas drawImageRect(Image image, Rect src, Rect dst, Paint paint, boolean strict) {
         Stats.onNativeCall();
-        _nDrawImageRect(_ptr, Native.getPtr(image), src._left, src._top, src._right, src._bottom, dst._left, dst._top, dst._right, dst._bottom, Native.getPtr(paint), strict);
+        _nDrawImageRect(_ptr, image, src._left, src._top, src._right, src._bottom, dst._left, dst._top, dst._right, dst._bottom, Native.getPtr(paint), strict);
         return this;
     }
 
@@ -292,7 +294,7 @@ public class Canvas extends Managed {
 
     public Canvas drawImageIRect(Image image, IRect src, Rect dst, Paint paint, boolean strict) {
         Stats.onNativeCall();
-        _nDrawImageIRect(_ptr, Native.getPtr(image), src._left, src._top, src._right, src._bottom, dst._left, dst._top, dst._right, dst._bottom, Native.getPtr(paint), strict);
+        _nDrawImageIRect(_ptr, image, src._left, src._top, src._right, src._bottom, dst._left, dst._top, dst._right, dst._bottom, Native.getPtr(paint), strict);
         return this;
     }
 
@@ -1019,8 +1021,8 @@ public class Canvas extends Managed {
     public static native void _nDrawRRect(long ptr, float left, float top, float right, float bottom, float[] radii, long paintPtr);
     public static native void _nDrawDRRect(long ptr, float ol, float ot, float or, float ob, float[] oradii, float il, float it, float ir, float ib, float[] iradii, long paintPtr);
     public static native void _nDrawPath(long ptr, long nativePath, long paintPtr);
-    public static native void _nDrawImageRect(long ptr, long nativeImage, float sl, float st, float sr, float sb, float dl, float dt, float dr, float db, long paintPtr, boolean strict);
-    public static native void _nDrawImageIRect(long ptr, long nativeImage, int sl, int st, int sr, int sb, float dl, float dt, float dr, float db, long paintPtr, boolean strict);
+    public static native void _nDrawImageRect(long ptr, Image image, float sl, float st, float sr, float sb, float dl, float dt, float dr, float db, long paintPtr, boolean strict);
+    public static native void _nDrawImageIRect(long ptr, Image image, int sl, int st, int sr, int sb, float dl, float dt, float dr, float db, long paintPtr, boolean strict);
     public static native void _nDrawBitmapRect(long ptr, long bitmapPtr, float sl, float st, float sr, float sb, float dl, float dt, float dr, float db, long paintPtr, boolean strict);
     public static native void _nDrawBitmapIRect(long ptr, long bitmapPtr, int sl, int st, int sr, int sb, float dl, float dt, float dr, float db, long paintPtr, boolean strict);
     public static native void _nDrawRegion(long ptr, long nativeRegion, long paintPtr);


### PR DESCRIPTION
…counterparts.

As described in https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219#24380219
it's not guaranteed that objects do not reach finalization queue even if they seemingly referred by local variables.
So as was seen in https://github.com/JetBrains/compose-jb/issues/124 we could invoke finalizer when long running native
method using resource is still in progress, and so - crash the VM.

In this fix we instead pass object handle to the JNI method instead, and it guarantees that object is reachable and not finalized.

This fix is POC, and generally scheme like that shall be applied to all objects with native counterparts in Skija.