### PR TITLE
Fix scale on high-dpi display on macos in clojure demos

### DIFF
--- a/examples/clojure-snake/src/snake/main.clj
+++ b/examples/clojure-snake/src/snake/main.clj
@@ -9,6 +9,12 @@
 
 (set! *warn-on-reflection* true)
 
+(defn display-scale [window]
+  (let [x (make-array Float/TYPE 1)
+        y (make-array Float/TYPE 1)]
+    (GLFW/glfwGetWindowContentScale window x y)
+    [(first x) (first y)]))
+
 (defn -main [& args]
   (.set (GLFWErrorCallback/createPrint System/err))
   (GLFW/glfwInit)
@@ -34,9 +40,11 @@
 
     (let [context (DirectContext/makeGL)
           fb-id   (GL11/glGetInteger 0x8CA6)
-          target  (BackendRenderTarget/makeGL width height 0 8 fb-id FramebufferFormat/GR_GL_RGBA8)
+          [scale-x scale-y] (display-scale window)
+          target  (BackendRenderTarget/makeGL (* scale-x width) (* scale-y height) 0 8 fb-id FramebufferFormat/GR_GL_RGBA8)
           surface (Surface/makeFromBackendRenderTarget context target SurfaceOrigin/BOTTOM_LEFT SurfaceColorFormat/RGBA_8888 (ColorSpace/getSRGB))
           canvas  (.getCanvas surface)]
+      (.scale canvas scale-x scale-y)
       (loop []
         (when (not (GLFW/glfwWindowShouldClose window))
           (let [layer (.save canvas)]

--- a/examples/clojure/src/lwjgl/main.clj
+++ b/examples/clojure/src/lwjgl/main.clj
@@ -20,6 +20,12 @@
     (.rotate canvas (mod (/ (System/currentTimeMillis) 10) 360))
     (.drawRect canvas (Rect/makeXYWH -50 -50 100 100) paint)))
 
+(defn display-scale [window]
+  (let [x (make-array Float/TYPE 1)
+        y (make-array Float/TYPE 1)]
+    (GLFW/glfwGetWindowContentScale window x y)
+    [(first x) (first y)]))
+
 (defn -main [& args]
   (.set (GLFWErrorCallback/createPrint System/err))
   (GLFW/glfwInit)
@@ -41,9 +47,11 @@
 
     (let [context (DirectContext/makeGL)
           fb-id   (GL11/glGetInteger 0x8CA6)
-          target  (BackendRenderTarget/makeGL width height 0 8 fb-id FramebufferFormat/GR_GL_RGBA8)
+          [scale-x scale-y] (display-scale window)
+          target  (BackendRenderTarget/makeGL (* scale-x width) (* scale-y height) 0 8 fb-id FramebufferFormat/GR_GL_RGBA8)
           surface (Surface/makeFromBackendRenderTarget context target SurfaceOrigin/BOTTOM_LEFT SurfaceColorFormat/RGBA_8888 (ColorSpace/getSRGB))
           canvas  (.getCanvas surface)]
+      (.scale canvas scale-x scale-y)
       (loop []
         (when (not (GLFW/glfwWindowShouldClose window))
           (.clear canvas (color 0xFFFFFFFF))


### PR DESCRIPTION
A corresponding change is also needed in the Kotlin sample app...

Without this change the content re-renders at 1/4 size for me after the first window event.

As an aside, would you be open to another PR with a few lines that improve the repl in the clojure demo to be more full-featured?