### PR TITLE
Update to support Skia m93

### DIFF
--- a/platform/cc/Paint.cc
+++ b/platform/cc/Paint.cc
@@ -40,12 +40,6 @@ extern "C" JNIEXPORT jboolean JNICALL Java_org_jetbrains_skija_Paint__1nEquals
     return *a == *b;
 }
 
-extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skija_Paint__1nGetHash
-  (JNIEnv* env, jclass jclass, jlong ptr) {
-    SkPaint* instance = reinterpret_cast<SkPaint*>(static_cast<uintptr_t>(ptr));
-    return instance->getHash();
-}
-
 extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skija_Paint__1nReset
   (JNIEnv* env, jclass jclass, jlong ptr) {
     SkPaint* instance = reinterpret_cast<SkPaint*>(static_cast<uintptr_t>(ptr));
@@ -100,19 +94,6 @@ extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skija_Paint__1nSetColor4f
     SkPaint* instance = reinterpret_cast<SkPaint*>(static_cast<uintptr_t>(ptr));
     SkColorSpace* colorSpace = reinterpret_cast<SkColorSpace*>(static_cast<uintptr_t>(colorSpacePtr));
     instance->setColor4f({r, g, b, a}, colorSpace);
-}
-
-extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skija_Paint__1nGetFilterQuality
-  (JNIEnv* env, jclass jclass, jlong ptr) {
-    SkPaint* instance = reinterpret_cast<SkPaint*>(static_cast<uintptr_t>(ptr));
-    return static_cast<jint>(instance->getFilterQuality());
-}
-
-extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skija_Paint__1nSetFilterQuality
-  (JNIEnv* env, jclass jclass, jlong ptr, jint jquality) {
-    SkPaint* instance = reinterpret_cast<SkPaint*>(static_cast<uintptr_t>(ptr));
-    SkFilterQuality quality = static_cast<SkFilterQuality>(jquality);
-    instance->setFilterQuality(quality);
 }
 
 extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skija_Paint__1nGetMode
@@ -223,7 +204,7 @@ extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skija_Paint__1nSetImageFilt
 extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skija_Paint__1nGetBlendMode
   (JNIEnv* env, jclass jclass, jlong ptr) {
     SkPaint* instance = reinterpret_cast<SkPaint*>(static_cast<uintptr_t>(ptr));
-    return static_cast<jlong>(instance->getBlendMode());
+    return static_cast<jlong>(instance->getBlendMode_or(SkBlendMode::kSrcOver));
 }
 
 extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skija_Paint__1nSetBlendMode

--- a/platform/cc/Shader.cc
+++ b/platform/cc/Shader.cc
@@ -142,10 +142,3 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skija_Shader__1nMakeBlend(
     SkShader* ptr = SkShaders::Blend(blendMode, sk_ref_sp<SkShader>(dst), sk_ref_sp<SkShader>(src)).release();
     return reinterpret_cast<jlong>(ptr);
 }
-
-extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skija_Shader__1nMakeLerp(JNIEnv* env, jclass jclass, jfloat t, jlong dstPtr, jlong srcPtr) {
-    SkShader* dst = reinterpret_cast<SkShader*>(static_cast<uintptr_t>(dstPtr));
-    SkShader* src = reinterpret_cast<SkShader*>(static_cast<uintptr_t>(srcPtr));
-    SkShader* ptr = SkShaders::Lerp(t, sk_ref_sp<SkShader>(dst), sk_ref_sp<SkShader>(src)).release();
-    return reinterpret_cast<jlong>(ptr);
-}

--- a/shared/java/Paint.java
+++ b/shared/java/Paint.java
@@ -60,25 +60,22 @@ public class Paint extends Managed {
     }
 
     /** 
-     * <p>Returns a hash generated from Paint values and pointers. Identical
+     * <del><p>Returns a hash generated from Paint values and pointers. Identical
      * hashes guarantee that the paints are equivalent, but differing hashes
      * do not guarantee that the paints have differing contents.</p>
      *
      * <p>If p1.equals(p2) returns true for two paints, their hashes are also equal.</p>
      *
-     * <p>The hash returned is platform and implementation specific.</p>
+     * <p>The hash returned is platform and implementation specific.</p></del>
+     * <p>In Skia</p>
      *
-     * @return  a shallow hash
+     * @return  hash based on pointer of the paint object
      * @see <a href="https://fiddle.skia.org/c/@Paint_getHash">https://fiddle.skia.org/c/@Paint_getHash</a>
+     * @see <a href="https://review.skia.org/419336">https://review.skia.org/419336</a>
      */
     @Override
     public int hashCode() {
-        try {
-            Stats.onNativeCall();
-            return _nGetHash(_ptr);
-        } finally {
-            Reference.reachabilityFence(this);
-        }
+        return java.util.Objects.hash(_ptr);
     }
 
     /**
@@ -142,38 +139,6 @@ public class Paint extends Managed {
     public Paint setDither(boolean value) {
         Stats.onNativeCall();
         _nSetDither(_ptr, value);
-        return this;
-    }
-
-    /**
-     * Returns FilterQuality, the image filtering level. A lower setting
-     * draws faster; a higher setting looks better when the image is scaled.
-     * 
-     * @return this
-     */
-    @NotNull
-    public FilterQuality getFilterQuality() {
-        try {
-            Stats.onNativeCall();
-            return FilterQuality.values()[_nGetFilterQuality(_ptr)];
-        } finally {
-            Reference.reachabilityFence(this);
-        }
-    }
-
-    /**
-     * Sets FilterQuality, the image filtering level. A lower setting
-     * draws faster; a higher setting looks better when the image is scaled.
-     * Does not check to see if quality is valid.
-     *
-     * @see <a href="https://fiddle.skia.org/c/@Color_Methods">https://fiddle.skia.org/c/@Color_Methods</a>
-     * @see <a href="https://fiddle.skia.org/c/@Paint_setFilterQuality">https://fiddle.skia.org/c/@Paint_setFilterQuality</a>
-     */
-    @NotNull @Contract("!null -> this; null -> fail")
-    public Paint setFilterQuality(@NotNull FilterQuality filterQuality) {
-        assert filterQuality != null : "Paint::setFilterQuality expected filterQuality != null";
-        Stats.onNativeCall();
-        _nSetFilterQuality(_ptr, filterQuality.ordinal());
         return this;
     }
 
@@ -586,7 +551,7 @@ public class Paint extends Managed {
      *
      * @return  mode used to combine source color with destination color
      */
-    @NotNull
+    @Nullable
     public BlendMode getBlendMode() {
         try {
             Stats.onNativeCall();
@@ -738,14 +703,11 @@ public class Paint extends Managed {
     public static native long  _nMake();
     public static native long  _nMakeClone(long ptr);
     public static native boolean _nEquals(long ptr, long otherPtr);
-    public static native int _nGetHash(long ptr);
     public static native void _nReset(long ptr);
     public static native boolean _nIsAntiAlias(long ptr);
     public static native void  _nSetAntiAlias(long ptr, boolean value);
     public static native boolean _nIsDither(long ptr);
     public static native void  _nSetDither(long ptr, boolean value);
-    public static native int   _nGetFilterQuality(long ptr);
-    public static native void  _nSetFilterQuality(long ptr, int quality);
     public static native int   _nGetMode(long ptr);
     public static native void  _nSetMode(long ptr, int value);
     public static native int   _nGetColor(long ptr);

--- a/shared/java/Shader.java
+++ b/shared/java/Shader.java
@@ -223,16 +223,6 @@ public class Shader extends RefCnt {
         }
     }
 
-    public static Shader makeLerp(float t, Shader dst, Shader src) {
-        try {
-            Stats.onNativeCall();
-            return new Shader(_nMakeLerp(t, Native.getPtr(dst), Native.getPtr(src)));
-        } finally {
-            Reference.reachabilityFence(dst);
-            Reference.reachabilityFence(src);
-        }
-    }
-
     @ApiStatus.Internal
     public Shader(long ptr) {
         super(ptr);
@@ -251,5 +241,4 @@ public class Shader extends RefCnt {
     public static native long _nMakeColor(int color);
     public static native long _nMakeColorCS(float r, float g, float b, float a, long colorSpacePtr);
     public static native long _nMakeBlend(int blendMode, long dst, long src);
-    public static native long _nMakeLerp(float t, long dst, long src);
 }


### PR DESCRIPTION
Copy from Skia RELEASE_NOTES:

Milestone 93
------------
  * Removed SkPaint::getHash
    https://review.skia.org/419336

  * Removed SkShaders::Lerp. It was unused (and easy to replicate with SkRuntimeEffect).
    https://review.skia.org/419796

BTW: SkMatrix44 is removed recently.