### PR TITLE
Fix source jar build on non-English Windows

### DIFF
--- a/script/deploy_shared.py
+++ b/script/deploy_shared.py
@@ -46,6 +46,7 @@ def main():
       print('Delomboking sources')
       subprocess.check_call([
         "java",
+        "-Dfile.encoding=UTF8",
         "-jar",
         lombok,
         "delombok",


### PR DESCRIPTION
`script/deploy_shared.py` fails on non-English Windows. `-Dfile.encoding=UTF8` is required when executing `java` for delomboking.

- Environment: Windows 10 x64 Build 19043, in Simplified Chinese Language (Codepage 936
- Command: `python .\script\deploy_platform.py --dry-run true --debug true --skia-dir <omitted>`