### PR TITLE
Add SkPixmap bindings, and add SkPixmap-related methods for SkSurface

### DIFF
--- a/platform/cc/Pixmap.cc
+++ b/platform/cc/Pixmap.cc
@@ -1,0 +1,191 @@
+#include <jni.h>
+#include "interop.hh"
+#include "SkPixmap.h"
+
+static void deletePixmap(SkPixmap *pixmap) {
+    delete pixmap;
+}
+
+template <typename T>
+inline T jlongToPtr(jlong ptr) {
+    return reinterpret_cast<T>(static_cast<uintptr_t>(ptr));
+}
+
+template <typename T>
+jlong ptrToJlong(T* ptr) {
+    return static_cast<jlong>(reinterpret_cast<uintptr_t>(ptr));
+}
+
+extern "C" {
+    JNIEXPORT jlong JNICALL Java_org_jetbrains_skija_Pixmap__1nGetFinalizer
+      (JNIEnv *env, jclass klass) {
+        return ptrToJlong(&deletePixmap);
+    }
+
+    JNIEXPORT jlong JNICALL Java_org_jetbrains_skija_Pixmap__1nMakeNull
+      (JNIEnv *env, jclass klass) {
+        return ptrToJlong(new SkPixmap());
+    }
+
+    JNIEXPORT jlong JNICALL Java_org_jetbrains_skija_Pixmap__1nMake
+      (JNIEnv *env, jclass klass,
+      jint width, jint height, jint colorType, jint alphaType, jlong colorSpacePtr, jlong pixelsPtr, jint rowBytes) {
+        SkColorSpace* colorSpace = jlongToPtr<SkColorSpace*>(colorSpacePtr);
+        SkImageInfo imageInfo = SkImageInfo::Make(width,
+                                              height,
+                                              static_cast<SkColorType>(colorType),
+                                              static_cast<SkAlphaType>(alphaType),
+                                              sk_ref_sp<SkColorSpace>(colorSpace));
+        return ptrToJlong(new SkPixmap(
+            imageInfo, jlongToPtr<void*>(pixelsPtr), rowBytes));
+    }
+
+    JNIEXPORT void JNICALL Java_org_jetbrains_skija_Pixmap__1nReset
+      (JNIEnv *env, jclass klass, jlong ptr) {
+        SkPixmap* pixmap = jlongToPtr<SkPixmap*>(ptr);
+        pixmap->reset();
+    }
+
+    JNIEXPORT void JNICALL Java_org_jetbrains_skija_Pixmap__1nResetWithInfo
+      (JNIEnv *env, jclass klass, jlong ptr,
+      jint width, jint height, jint colorType, jint alphaType, jlong colorSpacePtr, jlong pixelsPtr, jint rowBytes) {
+        SkPixmap* pixmap = jlongToPtr<SkPixmap*>(ptr);
+        SkColorSpace* colorSpace = jlongToPtr<SkColorSpace*>(colorSpacePtr);
+        SkImageInfo imageInfo = SkImageInfo::Make(width,
+                                              height,
+                                              static_cast<SkColorType>(colorType),
+                                              static_cast<SkAlphaType>(alphaType),
+                                              sk_ref_sp<SkColorSpace>(colorSpace));
+        pixmap->reset(imageInfo, jlongToPtr<void*>(pixelsPtr), rowBytes);
+    }
+
+    JNIEXPORT void JNICALL Java_org_jetbrains_skija_Pixmap__1nSetColorSpace
+      (JNIEnv *env, jclass klass, jlong ptr, jlong colorSpacePtr) {
+        SkPixmap* pixmap = jlongToPtr<SkPixmap*>(ptr);
+        SkColorSpace* colorSpace = jlongToPtr<SkColorSpace*>(colorSpacePtr);
+        pixmap->setColorSpace(sk_ref_sp<SkColorSpace>(colorSpace));
+    }
+
+    JNIEXPORT void JNICALL Java_org_jetbrains_skija_Pixmap__1nExtractSubset
+      (JNIEnv *env, jclass klass, jlong ptr,
+      jlong subsetPtr, jint l, jint t, jint w, jint h) {
+        SkPixmap* pixmap = jlongToPtr<SkPixmap*>(ptr);
+        SkPixmap* dst = jlongToPtr<SkPixmap*>(subsetPtr);
+        pixmap->extractSubset(dst, { l, t, w, h });
+    }
+
+    JNIEXPORT jobject JNICALL Java_org_jetbrains_skija_Pixmap__1nGetInfo
+      (JNIEnv *env, jclass klass, jlong ptr) {
+        SkPixmap* pixmap = jlongToPtr<SkPixmap*>(ptr);
+        const SkImageInfo& imageInfo = pixmap->info();
+        return skija::ImageInfo::toJava(env, imageInfo);
+    }
+
+    JNIEXPORT jint JNICALL Java_org_jetbrains_skija_Pixmap__1nGetRowBytes
+      (JNIEnv *env, jclass klass, jlong ptr) {
+        SkPixmap* pixmap = jlongToPtr<SkPixmap*>(ptr);
+        return static_cast<jint>(pixmap->rowBytes());
+    }
+
+    JNIEXPORT jlong JNICALL Java_org_jetbrains_skija_Pixmap__1nGetAddr
+      (JNIEnv *env, jclass klass, jlong ptr) {
+        SkPixmap* pixmap = jlongToPtr<SkPixmap*>(ptr);
+        return ptrToJlong(pixmap->addr());
+    }
+
+    JNIEXPORT jint JNICALL Java_org_jetbrains_skija_Pixmap__1nGetRowBytesAsPixels
+      (JNIEnv *env, jclass klass, jlong ptr) {
+        SkPixmap* pixmap = jlongToPtr<SkPixmap*>(ptr);
+        return static_cast<jint>(pixmap->rowBytesAsPixels());
+    }
+
+    JNIEXPORT jint JNICALL Java_org_jetbrains_skija_Pixmap__1nComputeByteSize
+      (JNIEnv *env, jclass klass, jlong ptr) {
+        SkPixmap* pixmap = jlongToPtr<SkPixmap*>(ptr);
+        return static_cast<jint>(pixmap->computeByteSize());
+    }
+
+    JNIEXPORT jboolean JNICALL Java_org_jetbrains_skija_Pixmap__1nComputeIsOpaque
+      (JNIEnv *env, jclass klass, jlong ptr) {
+        SkPixmap* pixmap = jlongToPtr<SkPixmap*>(ptr);
+        return static_cast<jboolean>(pixmap->computeIsOpaque());
+    }
+
+    JNIEXPORT jint JNICALL Java_org_jetbrains_skija_Pixmap__1nGetColor
+      (JNIEnv *env, jclass klass, jlong ptr, jint x, jint y) {
+        SkPixmap* pixmap = jlongToPtr<SkPixmap*>(ptr);
+        return static_cast<jint>(pixmap->getColor(x, y));
+    }
+
+    JNIEXPORT jfloat JNICALL Java_org_jetbrains_skija_Pixmap__1nGetAlphaF
+      (JNIEnv *env, jclass klass, jlong ptr, jint x, jint y) {
+        SkPixmap* pixmap = jlongToPtr<SkPixmap*>(ptr);
+        return static_cast<jfloat>(pixmap->getAlphaf(x, y));
+    }
+
+    JNIEXPORT jlong JNICALL Java_org_jetbrains_skija_Pixmap__1nGetAddrAt
+      (JNIEnv *env, jclass klass, jlong ptr, jint x, jint y) {
+        SkPixmap* pixmap = jlongToPtr<SkPixmap*>(ptr);
+        return reinterpret_cast<jlong>(pixmap->addr(x, y));
+    }
+
+    JNIEXPORT jboolean JNICALL Java_org_jetbrains_skija_Pixmap__1nReadPixels
+      (JNIEnv *env, jclass klass, jlong ptr,
+      jint width, jint height, jint colorType, jint alphaType, jlong colorSpacePtr, jlong pixelsPtr, jint rowBytes) {
+        SkPixmap* pixmap = jlongToPtr<SkPixmap*>(ptr);
+        SkColorSpace* colorSpace = jlongToPtr<SkColorSpace*>(colorSpacePtr);
+        SkImageInfo imageInfo = SkImageInfo::Make(width,
+                                              height,
+                                              static_cast<SkColorType>(colorType),
+                                              static_cast<SkAlphaType>(alphaType),
+                                              sk_ref_sp<SkColorSpace>(colorSpace));
+        return static_cast<jboolean>(pixmap->readPixels(imageInfo, jlongToPtr<void*>(pixelsPtr), rowBytes));
+    }
+
+    JNIEXPORT jboolean JNICALL Java_org_jetbrains_skija_Pixmap__1nReadPixelsFromPoint
+      (JNIEnv *env, jclass klass, jlong ptr,
+      jint width, jint height, jint colorType, jint alphaType, jlong colorSpacePtr, jlong pixelsPtr, jint rowBytes,
+      jint srcX, jint srcY) {
+        SkPixmap* pixmap = jlongToPtr<SkPixmap*>(ptr);
+        SkColorSpace* colorSpace = jlongToPtr<SkColorSpace*>(colorSpacePtr);
+        SkImageInfo imageInfo = SkImageInfo::Make(width,
+                                              height,
+                                              static_cast<SkColorType>(colorType),
+                                              static_cast<SkAlphaType>(alphaType),
+                                              sk_ref_sp<SkColorSpace>(colorSpace));
+        return static_cast<jboolean>(pixmap->readPixels(imageInfo, jlongToPtr<void*>(pixelsPtr), rowBytes, srcX, srcY));
+    }
+
+    JNIEXPORT jboolean JNICALL Java_org_jetbrains_skija_Pixmap__1nReadPixelsToPixmap
+      (JNIEnv *env, jclass klass, jlong ptr, jlong dstPixmapPtr) {
+        SkPixmap* pixmap = jlongToPtr<SkPixmap*>(ptr);
+        SkPixmap* dstPixmap = jlongToPtr<SkPixmap*>(dstPixmapPtr);
+        return static_cast<jboolean>(pixmap->readPixels(*dstPixmap));
+    }
+
+    JNIEXPORT jboolean JNICALL Java_org_jetbrains_skija_Pixmap__1nReadPixelsToPixmapFromPoint
+      (JNIEnv *env, jclass klass, jlong ptr, jlong dstPixmapPtr, jint srcX, jint srcY) {
+        SkPixmap* pixmap = jlongToPtr<SkPixmap*>(ptr);
+        SkPixmap* dstPixmap = jlongToPtr<SkPixmap*>(dstPixmapPtr);
+        return static_cast<jboolean>(pixmap->readPixels(*dstPixmap, srcX, srcY));
+    }
+
+    JNIEXPORT jboolean JNICALL Java_org_jetbrains_skija_Pixmap__1nScalePixels
+      (JNIEnv *env, jclass klass, jlong ptr, jlong dstPixmapPtr, jlong samplingOptions) {
+        SkPixmap* pixmap = jlongToPtr<SkPixmap*>(ptr);
+        SkPixmap* dstPixmap = jlongToPtr<SkPixmap*>(dstPixmapPtr);
+        return static_cast<jboolean>(pixmap->scalePixels(*dstPixmap, skija::SamplingMode::unpack(samplingOptions)));
+    }
+
+    JNIEXPORT jboolean JNICALL Java_org_jetbrains_skija_Pixmap__1nErase
+      (JNIEnv *env, jclass klass, jlong ptr, jint color) {
+        SkPixmap* pixmap = jlongToPtr<SkPixmap*>(ptr);
+        return static_cast<jboolean>(pixmap->erase(color));
+    }
+
+    JNIEXPORT jboolean JNICALL Java_org_jetbrains_skija_Pixmap__1nEraseSubset
+      (JNIEnv *env, jclass klass, jlong ptr, jint color, jint l, jint t, jint w, jint h) {
+        SkPixmap* pixmap = jlongToPtr<SkPixmap*>(ptr);
+        return static_cast<jboolean>(pixmap->erase(color, { l, t, w, h }));
+    }
+}

--- a/platform/cc/Pixmap.cc
+++ b/platform/cc/Pixmap.cc
@@ -6,16 +6,6 @@ static void deletePixmap(SkPixmap *pixmap) {
     delete pixmap;
 }
 
-template <typename T>
-inline T jlongToPtr(jlong ptr) {
-    return reinterpret_cast<T>(static_cast<uintptr_t>(ptr));
-}
-
-template <typename T>
-jlong ptrToJlong(T* ptr) {
-    return static_cast<jlong>(reinterpret_cast<uintptr_t>(ptr));
-}
-
 extern "C" {
     JNIEXPORT jlong JNICALL Java_org_jetbrains_skija_Pixmap__1nGetFinalizer
       (JNIEnv *env, jclass klass) {

--- a/platform/cc/Surface.cc
+++ b/platform/cc/Surface.cc
@@ -7,7 +7,7 @@
 extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skija_Surface__1nMakeRasterDirect
   (JNIEnv* env, jclass jclass,
     jint width, jint height, jint colorType, jint alphaType, jlong colorSpacePtr,
-    jlong pixelsPtr, jlong rowBytes, 
+    jlong pixelsPtr, jlong rowBytes,
     jobject surfacePropsObj)
 {
     SkColorSpace* colorSpace = reinterpret_cast<SkColorSpace*>(static_cast<uintptr_t>(colorSpacePtr));
@@ -26,10 +26,21 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skija_Surface__1nMakeRaste
     return reinterpret_cast<jlong>(instance.release());
 }
 
+extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skija_Surface__1nMakeRasterDirectWithPixmap
+  (JNIEnv* env, jclass jclass,
+    jlong pixmapPtr, jobject surfacePropsObj)
+{
+    SkPixmap* pixmap = reinterpret_cast<SkPixmap*>(static_cast<uintptr_t>(pixmapPtr));
+    std::unique_ptr<SkSurfaceProps> surfaceProps = skija::SurfaceProps::toSkSurfaceProps(env, surfacePropsObj);
+
+    sk_sp<SkSurface> instance = SkSurface::MakeRasterDirect(*pixmap, surfaceProps.get());
+    return reinterpret_cast<jlong>(instance.release());
+}
+
 extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skija_Surface__1nMakeRaster
   (JNIEnv* env, jclass jclass,
     jint width, jint height, jint colorType, jint alphaType, jlong colorSpacePtr,
-    jlong rowBytes, 
+    jlong rowBytes,
     jobject surfacePropsObj)
 {
     SkColorSpace* colorSpace = reinterpret_cast<SkColorSpace*>(static_cast<uintptr_t>(colorSpacePtr));
@@ -101,9 +112,9 @@ extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skija_Surface__1nMakeFromM
 #endif
 
 extern "C" JNIEXPORT jlong JNICALL Java_org_jetbrains_skija_Surface__1nMakeRenderTarget
-  (JNIEnv* env, jclass jclass, jlong contextPtr, jboolean budgeted, 
+  (JNIEnv* env, jclass jclass, jlong contextPtr, jboolean budgeted,
     jint width, jint height, jint colorType, jint alphaType, jlong colorSpacePtr,
-    jint sampleCount, jint surfaceOrigin, 
+    jint sampleCount, jint surfaceOrigin,
     jobject surfacePropsObj,
     jboolean shouldCreateWithMips)
 {
@@ -167,11 +178,25 @@ extern "C" JNIEXPORT jint JNICALL Java_org_jetbrains_skija_Surface__1nGeneration
     return surface->generationID();
 }
 
+extern "C" JNIEXPORT jboolean JNICALL Java_org_jetbrains_skija_Surface__1nReadPixelsToPixmap
+  (JNIEnv* env, jclass jclass, jlong ptr, jlong pixmapPtr, jint srcX, jint srcY) {
+    SkSurface* surface = reinterpret_cast<SkSurface*>(static_cast<uintptr_t>(ptr));
+    SkPixmap* pixmap = reinterpret_cast<SkPixmap*>(static_cast<uintptr_t>(pixmapPtr));
+    return surface->readPixels(*pixmap, srcX, srcY);
+}
+
 extern "C" JNIEXPORT jboolean JNICALL Java_org_jetbrains_skija_Surface__1nReadPixels
   (JNIEnv* env, jclass jclass, jlong ptr, jlong bitmapPtr, jint srcX, jint srcY) {
     SkSurface* surface = reinterpret_cast<SkSurface*>(static_cast<uintptr_t>(ptr));
     SkBitmap* bitmap = reinterpret_cast<SkBitmap*>(static_cast<uintptr_t>(bitmapPtr));
     return surface->readPixels(*bitmap, srcX, srcY);
+}
+
+extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skija_Surface__1nWritePixelsFromPixmap
+  (JNIEnv* env, jclass jclass, jlong ptr, jlong pixmapPtr, jint x, jint y) {
+    SkSurface* surface = reinterpret_cast<SkSurface*>(static_cast<uintptr_t>(ptr));
+    SkPixmap* pixmap = reinterpret_cast<SkPixmap*>(static_cast<uintptr_t>(pixmapPtr));
+    surface->writePixels(*pixmap, x, y);
 }
 
 extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skija_Surface__1nWritePixels
@@ -237,6 +262,13 @@ extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skija_Surface__1nDraw
     SkCanvas* canvas = reinterpret_cast<SkCanvas*>(static_cast<uintptr_t>(canvasPtr));
     SkPaint* paint = reinterpret_cast<SkPaint*>(static_cast<uintptr_t>(paintPtr));
     surface->draw(canvas, x, y, paint);
+}
+
+extern "C" JNIEXPORT jboolean JNICALL Java_org_jetbrains_skija_Surface__1nPeekPixels
+  (JNIEnv *env, jclass jclass, jlong ptr, jlong dstPixmapPtr) {
+    SkSurface* surface = reinterpret_cast<SkSurface*>(static_cast<uintptr_t>(ptr));
+    SkPixmap* pixmap = reinterpret_cast<SkPixmap*>(static_cast<uintptr_t>(dstPixmapPtr));
+    return static_cast<jboolean>(surface->peekPixels(pixmap));
 }
 
 extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skija_Surface__1nNotifyContentWillChange

--- a/platform/cc/impl/BufferUtil.cc
+++ b/platform/cc/impl/BufferUtil.cc
@@ -1,0 +1,19 @@
+#include <jni.h>
+#include "../interop.hh"
+
+namespace {
+    jclass klass_IllegalArgumentException = nullptr;
+    jmethodID method_Ctor = nullptr;
+}
+
+extern "C" {
+    JNIEXPORT jobject JNICALL Java_org_jetbrains_skija_impl_BufferUtil__1nGetByteBufferFromPointer
+      (JNIEnv *env, jclass, jlong ptr, jint size) {
+        return env->NewDirectByteBuffer(jlongToPtr<void*>(ptr), size);
+    }
+
+    JNIEXPORT jlong JNICALL Java_org_jetbrains_skija_impl_BufferUtil__1nGetPointerFromByteBuffer
+      (JNIEnv *env, jclass, jobject buffer) {
+        return ptrToJlong(env->GetDirectBufferAddress(buffer));
+    }
+}

--- a/platform/cc/interop.hh
+++ b/platform/cc/interop.hh
@@ -123,7 +123,7 @@ namespace skija {
         void onLoad(JNIEnv* env);
         void onUnload(JNIEnv* env);
     }
-    
+
     namespace FontFamilyName {
         extern jclass cls;
         extern jmethodID ctor;
@@ -272,7 +272,7 @@ namespace skija {
         void onLoad(JNIEnv* env);
         void onUnload(JNIEnv* env);
         SkRRect toSkRRect(JNIEnv* env, jfloat left, jfloat top, jfloat right, jfloat bottom, jfloatArray jradii);
-        jobject fromSkRRect(JNIEnv* env, const SkRRect& rect);   
+        jobject fromSkRRect(JNIEnv* env, const SkRRect& rect);
     }
 
     namespace RSXform {
@@ -343,3 +343,13 @@ std::vector<SkString> skStringVector(JNIEnv* env, jobjectArray arr);
 jobjectArray javaStringArray(JNIEnv* env, const std::vector<SkString>& strings);
 
 void deleteJBytes(void* addr, void*);
+
+template <typename T>
+inline T jlongToPtr(jlong ptr) {
+    return reinterpret_cast<T>(static_cast<uintptr_t>(ptr));
+}
+
+template <typename T>
+jlong ptrToJlong(T* ptr) {
+    return static_cast<jlong>(reinterpret_cast<uintptr_t>(ptr));
+}

--- a/shared/java/Pixmap.java
+++ b/shared/java/Pixmap.java
@@ -1,0 +1,257 @@
+package org.jetbrains.skija;
+
+import java.lang.ref.*;
+import org.jetbrains.annotations.*;
+import org.jetbrains.skija.IRect;
+import org.jetbrains.skija.ImageInfo;
+import org.jetbrains.skija.SamplingMode;
+import org.jetbrains.skija.impl.*;
+
+public class Pixmap extends Managed {
+    @ApiStatus.Internal
+    public Pixmap(long ptr, boolean managed) {
+        super(ptr, _FinalizerHolder.PTR, managed);
+    }
+
+    public Pixmap() {
+        this(_nMakeNull(), true);
+        Stats.onNativeCall();
+    }
+
+    public static Pixmap make(ImageInfo info, long addr, int rowBytes) {
+        try {
+            long ptr = _nMake(
+                info._width, info._height,
+                info._colorInfo._colorType.ordinal(),
+                info._colorInfo._alphaType.ordinal(),
+                Native.getPtr(info._colorInfo._colorSpace), addr, rowBytes);
+            if (ptr == 0)
+                throw new IllegalArgumentException("Failed to create Pixmap.");
+            return new Pixmap(ptr, true);
+        } finally {
+            Reference.reachabilityFence(info._colorInfo._colorSpace);
+        }
+    }
+
+    public void reset() {
+        Stats.onNativeCall();
+        _nReset(_ptr);
+        Reference.reachabilityFence(this);
+    }
+
+    public void reset(ImageInfo info, long addr, int rowBytes) {
+        Stats.onNativeCall();
+        _nResetWithInfo(_ptr,
+            info._width, info._height,
+            info._colorInfo._colorType.ordinal(),
+            info._colorInfo._alphaType.ordinal(),
+            Native.getPtr(info._colorInfo._colorSpace), addr, rowBytes);
+        Reference.reachabilityFence(this);
+        Reference.reachabilityFence(info._colorInfo._colorSpace);
+    }
+
+    public void setColorSpace(ColorSpace colorSpace) {
+        Stats.onNativeCall();
+        _nSetColorSpace(_ptr, Native.getPtr(colorSpace));
+        Reference.reachabilityFence(this);
+        Reference.reachabilityFence(colorSpace);
+    }
+
+    public void extractSubset(long subsetPtr, IRect area) {
+        Stats.onNativeCall();
+        _nExtractSubset(_ptr, subsetPtr, area._left, area._top, area._right, area._bottom);
+        Reference.reachabilityFence(this);
+    }
+
+    public ImageInfo getInfo() {
+        Stats.onNativeCall();
+        try {
+            return _nGetInfo(_ptr);
+        } finally {
+            Reference.reachabilityFence(this);
+        }
+    }
+
+    public int getRowBytes() {
+        Stats.onNativeCall();
+        try {
+            return _nGetRowBytes(_ptr);
+        } finally {
+            Reference.reachabilityFence(this);
+        }
+    }
+
+    public long getAddr() {
+        Stats.onNativeCall();
+        try {
+            return _nGetAddr(_ptr);
+        } finally {
+            Reference.reachabilityFence(this);
+        }
+    }
+
+    public int getRowBytesAsPixels() {
+        Stats.onNativeCall();
+        try {
+            return _nGetRowBytesAsPixels(_ptr);
+        } finally {
+            Reference.reachabilityFence(this);
+        }
+    }
+
+    public int computeByteSize() {
+        Stats.onNativeCall();
+        try {
+            return _nComputeByteSize(_ptr);
+        } finally {
+            Reference.reachabilityFence(this);
+        }
+    }
+
+    public boolean computeIsOpaque() {
+        Stats.onNativeCall();
+        try {
+            return _nComputeIsOpaque(_ptr);
+        } finally {
+            Reference.reachabilityFence(this);
+        }
+    }
+
+    public int getColor(int x, int y) {
+        Stats.onNativeCall();
+        try {
+            return _nGetColor(_ptr, x, y);
+        } finally {
+            Reference.reachabilityFence(this);
+        }
+    }
+
+    public float getAlphaF(int x, int y) {
+        Stats.onNativeCall();
+        try {
+            return _nGetAlphaF(_ptr, x, y);
+        } finally {
+            Reference.reachabilityFence(this);
+        }
+    }
+
+    public long getAddr(int x, int y) {
+        Stats.onNativeCall();
+        try {
+            return _nGetAddrAt(_ptr, x, y);
+        } finally {
+            Reference.reachabilityFence(this);
+        }
+    }
+
+    public boolean readPixels(ImageInfo info, long addr, int rowBytes) {
+        Stats.onNativeCall();
+        try {
+            return _nReadPixels(_ptr,
+                info._width, info._height,
+                info._colorInfo._colorType.ordinal(),
+                info._colorInfo._alphaType.ordinal(),
+                Native.getPtr(info._colorInfo._colorSpace), addr, rowBytes);
+        } finally {
+            Reference.reachabilityFence(this);
+            Reference.reachabilityFence(info._colorInfo._colorSpace);
+        }
+    }
+
+    public boolean readPixels(ImageInfo info, long addr, int rowBytes, int srcX, int srcY) {
+        Stats.onNativeCall();
+        try {
+            return _nReadPixelsFromPoint(_ptr,
+                info._width, info._height,
+                info._colorInfo._colorType.ordinal(),
+                info._colorInfo._alphaType.ordinal(),
+                Native.getPtr(info._colorInfo._colorSpace), addr, rowBytes,
+                srcX, srcY);
+        } finally {
+            Reference.reachabilityFence(this);
+            Reference.reachabilityFence(info._colorInfo._colorSpace);
+        }
+    }
+
+    public boolean readPixels(Pixmap pixmap) {
+        Stats.onNativeCall();
+        try {
+            return _nReadPixelsToPixmap(_ptr, Native.getPtr(pixmap));
+        } finally {
+            Reference.reachabilityFence(this);
+            Reference.reachabilityFence(pixmap);
+        }
+    }
+
+    public boolean readPixels(Pixmap pixmap, int srcX, int srcY) {
+        Stats.onNativeCall();
+        try {
+            return _nReadPixelsToPixmapFromPoint(_ptr, Native.getPtr(pixmap), srcX, srcY);
+        } finally {
+            Reference.reachabilityFence(this);
+            Reference.reachabilityFence(pixmap);
+        }
+    }
+
+    public boolean scalePixels(Pixmap dstPixmap, SamplingMode samplingMode) {
+        Stats.onNativeCall();
+        try {
+            return _nScalePixels(_ptr, Native.getPtr(dstPixmap), samplingMode._pack());
+        } finally {
+            Reference.reachabilityFence(this);
+            Reference.reachabilityFence(dstPixmap);
+        }
+    }
+
+    public boolean erase(int color) {
+        Stats.onNativeCall();
+        try {
+            return _nErase(_ptr, color);
+        } finally {
+            Reference.reachabilityFence(this);
+        }
+    }
+
+    public boolean erase(int color, IRect subset) {
+        Stats.onNativeCall();
+        try {
+            return _nEraseSubset(_ptr, color, subset._left, subset._top, subset._right, subset._bottom);
+        } finally {
+            Reference.reachabilityFence(this);
+        }
+    }
+
+    @ApiStatus.Internal
+    public static class _FinalizerHolder {
+        public static final long PTR = _nGetFinalizer();
+    }
+
+    public static native long _nGetFinalizer();
+    public static native long _nMakeNull();
+    public static native long _nMake(int width, int height, int colorType, int alphaType, long colorSpacePtr, long pixelsPtr, int rowBytes);
+
+    public static native void _nReset(long ptr);
+    public static native void _nResetWithInfo(long ptr, int width, int height, int colorType, int alphaType, long colorSpacePtr, long pixelsPtr, int rowBytes);
+    public static native void _nSetColorSpace(long ptr, long colorSpacePtr);
+    public static native void _nExtractSubset(long ptr, long subsetPtr, int l, int t, int r, int b);
+    public static native ImageInfo _nGetInfo(long ptr);
+    public static native int _nGetRowBytes(long ptr);
+    public static native long _nGetAddr(long ptr);
+    // TODO methods flattening ImageInfo not included yet - use GetInfo() instead.
+    public static native int _nGetRowBytesAsPixels(long ptr);
+    // TODO shiftPerPixel
+    public static native int _nComputeByteSize(long ptr);
+    public static native boolean _nComputeIsOpaque(long ptr);
+    public static native int _nGetColor(long ptr, int x, int y);
+    public static native float _nGetAlphaF(long ptr, int x, int y);
+    public static native long _nGetAddrAt(long ptr, int x, int y);
+    // methods related to C++ types(addr8/16/32/64, writable_addr8/16/32/64) not included - not needed
+    public static native boolean _nReadPixels(long ptr, int width, int height, int colorType, int alphaType, long colorSpacePtr, long dstPixelsPtr, int dstRowBytes);
+    public static native boolean _nReadPixelsFromPoint(long ptr, int width, int height, int colorType, int alphaType, long colorSpacePtr, long dstPixelsPtr, int dstRowBytes, int srcX, int srcY);
+    public static native boolean _nReadPixelsToPixmap(long ptr, long dstPixmapPtr);
+    public static native boolean _nReadPixelsToPixmapFromPoint(long ptr, long dstPixmapPtr, int srcX, int srcY);
+    public static native boolean _nScalePixels(long ptr, long dstPixmapPtr, long samplingOptions);
+    public static native boolean _nErase(long ptr, int color);
+    public static native boolean _nEraseSubset(long ptr, int color, int l, int t, int r, int b);
+    // TODO float erase methods not included
+}

--- a/shared/java/Pixmap.java
+++ b/shared/java/Pixmap.java
@@ -1,6 +1,7 @@
 package org.jetbrains.skija;
 
 import java.lang.ref.*;
+import java.nio.ByteBuffer;
 import org.jetbrains.annotations.*;
 import org.jetbrains.skija.IRect;
 import org.jetbrains.skija.ImageInfo;
@@ -16,6 +17,10 @@ public class Pixmap extends Managed {
     public Pixmap() {
         this(_nMakeNull(), true);
         Stats.onNativeCall();
+    }
+
+    public static Pixmap make(ImageInfo info, ByteBuffer buffer, int rowBytes) {
+        return make(info, BufferUtil.getPointerFromByteBuffer(buffer), rowBytes);
     }
 
     public static Pixmap make(ImageInfo info, long addr, int rowBytes) {
@@ -50,6 +55,10 @@ public class Pixmap extends Managed {
         Reference.reachabilityFence(info._colorInfo._colorSpace);
     }
 
+    public void reset(ImageInfo info, ByteBuffer buffer, int rowBytes) {
+        reset(info, BufferUtil.getPointerFromByteBuffer(buffer), rowBytes);
+    }
+
     public void setColorSpace(ColorSpace colorSpace) {
         Stats.onNativeCall();
         _nSetColorSpace(_ptr, Native.getPtr(colorSpace));
@@ -61,6 +70,10 @@ public class Pixmap extends Managed {
         Stats.onNativeCall();
         _nExtractSubset(_ptr, subsetPtr, area._left, area._top, area._right, area._bottom);
         Reference.reachabilityFence(this);
+    }
+
+    public void extractSubset(ByteBuffer buffer, IRect area) {
+        extractSubset(BufferUtil.getPointerFromByteBuffer(buffer), area);
     }
 
     public ImageInfo getInfo() {
@@ -219,6 +232,10 @@ public class Pixmap extends Managed {
         } finally {
             Reference.reachabilityFence(this);
         }
+    }
+
+    public ByteBuffer getBuffer() {
+        return BufferUtil.getByteBufferFromPointer(getAddr(), computeByteSize());
     }
 
     @ApiStatus.Internal

--- a/shared/java/impl/BufferUtil.java
+++ b/shared/java/impl/BufferUtil.java
@@ -1,0 +1,22 @@
+package org.jetbrains.skija.impl;
+
+import java.nio.ByteBuffer;
+
+public class BufferUtil {
+    public static ByteBuffer getByteBufferFromPointer(long ptr, int size) {
+        ByteBuffer result = _nGetByteBufferFromPointer(ptr, size);
+        if (result == null)
+            throw new IllegalArgumentException("JNI direct buffer access not support by current JVM!");
+        return result;
+    }
+
+    public static long getPointerFromByteBuffer(ByteBuffer buffer) {
+        long result = _nGetPointerFromByteBuffer(buffer);
+        if (result == 0)
+            throw new IllegalArgumentException("The given buffer " + buffer + "is not a direct buffer or current JVM doesn't support JNI direct buffer access!");
+        return result;
+    }
+
+    public static native ByteBuffer _nGetByteBufferFromPointer(long ptr, int size);
+    public static native long _nGetPointerFromByteBuffer(ByteBuffer buffer);
+}


### PR DESCRIPTION
Almost all SkPixmap bindings are done, except for some unnecessary or C++-bound methods.

Note the `jlongToPtr` and `ptrToJlong`: It's recommended to replace all those `reinterpret_cast`s and `static_cast`s for `jlong` pointer conversions with invocations to these two methods. But I currently don't have the time to do that :(

Additionally, a `BufferUtil` is introduced, therefore easy conversion between `long` pointers and `DirectByteBuffer` is enabled.