### PR TITLE
DirectContext: expose submit method (for dx12 integration)

### DIFF
--- a/platform/cc/DirectContext.cc
+++ b/platform/cc/DirectContext.cc
@@ -45,6 +45,12 @@ extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skija_DirectContext__1nFlus
     context->flush(GrFlushInfo());
 }
 
+extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skija_DirectContext__1nSubmit
+  (JNIEnv* env, jclass jclass, jlong ptr, jboolean syncCpu) {
+    GrDirectContext* context = reinterpret_cast<GrDirectContext*>(static_cast<uintptr_t>(ptr));
+    context->submit(syncCpu);
+}
+
 extern "C" JNIEXPORT void JNICALL Java_org_jetbrains_skija_DirectContext__1nReset
   (JNIEnv* env, jclass jclass, jlong ptr, jint flags) {
     GrDirectContext* context = reinterpret_cast<GrDirectContext*>(static_cast<uintptr_t>(ptr));

--- a/shared/java/DirectContext.java
+++ b/shared/java/DirectContext.java
@@ -68,6 +68,18 @@ public class DirectContext extends RefCnt {
     }
 
     /**
+     * <p>Submit outstanding work to the gpu from all previously un-submitted flushes.</p>
+     * <p>If the syncCpu flag is true this function will return once the gpu has finished with all submitted work.</p>
+     * <p>For more information refer to skia GrDirectContext::submit(bool syncCpu) method.</p>
+     * 
+     * @param syncCpu flag to sync cpu and gpu work submission
+     */ 
+    public void submit(boolean syncCpu) {
+        Stats.onNativeCall();
+        _nSubmit(_ptr, syncCpu);
+    }
+
+    /**
      * <p>Abandons all GPU resources and assumes the underlying backend 3D API context is no longer
      * usable. Call this if you have lost the associated GPU context, and thus internal texture,
      * buffer, etc. references/IDs are now invalid. Calling this ensures that the destructors of the
@@ -102,6 +114,7 @@ public class DirectContext extends RefCnt {
     @ApiStatus.Internal public static native long _nMakeMetal(long devicePtr, long queuePtr);
     @ApiStatus.Internal public static native long _nMakeDirect3D(long adapterPtr, long devicePtr, long queuePtr);
     @ApiStatus.Internal public static native long _nFlush(long ptr);
+    @ApiStatus.Internal public static native long _nSubmit(long ptr, boolean syncCpu);
     @ApiStatus.Internal public static native void _nReset(long ptr, int flags);
     @ApiStatus.Internal public static native void _nAbandon(long ptr);
 }


### PR DESCRIPTION
Expose DirectContext submit method, required to correctly resize swapchain in dx12.
Although Surface flush and submit methods are called, it seems that DirectContext still has some pending work and as well has some references to native dx12 resource, therefore it is impossible to correctly resize swapchain. Solution: destroy DirectContext or call submit(syncCpu = true) as shown here [skia dx12 demo](https://github.com/google/skia/blob/0d9a079079311aead160374c99a6717c3d21044f/tools/sk_app/win/D3D12WindowContext_win.cpp#L214)