### PR TITLE
Fix small typo in code in Getting Started.md

### DIFF
--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -67,7 +67,7 @@ try
     ByteChannel channel = Files.newByteChannel(
         path,
         StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
-    channel.write(pngBytes.toByteBuffer());
+    channel.write(pngBytes);
     channel.close();
 }
 catch (IOException e)


### PR DESCRIPTION
In the *Rendering the first image* paragraph, `pngBytes` is already a `ByteBuffer`.